### PR TITLE
Fix order_id missing in OrderProduct schema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -66,6 +66,7 @@ class OrderProductBase(BaseModel):
     quantity: int
 
 class OrderProduct(OrderProductBase):
+    order_id: int
     product_id: int
 
     class Config:


### PR DESCRIPTION
## Summary
- fix OrderProduct schema by including `order_id`

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile app/*.py upload_data_to_db.py`


------
https://chatgpt.com/codex/tasks/task_e_684dcfe8299c8325a1d6260d0c085168