### PR TITLE
Refactor product tables to support multiple product types

### DIFF
--- a/alembic/versions/7c2e9f3b7a9a_split_product_tables.py
+++ b/alembic/versions/7c2e9f3b7a9a_split_product_tables.py
@@ -1,0 +1,71 @@
+"""Split product table and add 3D model tables
+
+Revision ID: 7c2e9f3b7a9a
+Revises: 336e981c18a7
+Create Date: 2024-09-03 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '7c2e9f3b7a9a'
+down_revision: Union[str, None] = '336e981c18a7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'three_d_models',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('product_id', sa.Integer(), nullable=False, unique=True),
+        sa.Column('height', sa.Numeric(10, 2), nullable=False),
+        sa.Column('length', sa.Numeric(10, 2), nullable=False),
+        sa.Column('width', sa.Numeric(10, 2), nullable=False),
+        sa.ForeignKeyConstraint(['product_id'], ['products.id'])
+    )
+    op.create_table(
+        'model3d_media',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('model3d_id', sa.Integer(), nullable=False),
+        sa.Column('media_type', sa.String(), nullable=False),
+        sa.Column('filename', sa.String(), nullable=False),
+        sa.Column('content_type', sa.String(), nullable=False),
+        sa.Column('data', sa.LargeBinary(), nullable=False),
+        sa.ForeignKeyConstraint(['model3d_id'], ['three_d_models.id'])
+    )
+    op.add_column('products', sa.Column('product_type', sa.String(), nullable=False))
+    op.add_column('products', sa.Column('price', sa.Numeric(10, 2), nullable=False))
+    op.add_column('products', sa.Column('discount', sa.Numeric(10, 2), nullable=True))
+    op.add_column('products', sa.Column('discounted_price', sa.Numeric(10, 2), nullable=True))
+    op.drop_column('products', 'production_cost')
+    op.drop_column('products', 'selling_cost')
+    op.drop_column('products', 'height')
+    op.drop_column('products', 'length')
+    op.drop_column('products', 'depth')
+    op.drop_table('product_media')
+
+
+def downgrade() -> None:
+    op.create_table(
+        'product_media',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('product_id', sa.Integer(), nullable=False),
+        sa.Column('media_type', sa.String(), nullable=False),
+        sa.Column('filename', sa.String(), nullable=False),
+        sa.Column('content_type', sa.String(), nullable=False),
+        sa.Column('data', sa.LargeBinary(), nullable=False),
+        sa.ForeignKeyConstraint(['product_id'], ['products.id'])
+    )
+    op.add_column('products', sa.Column('depth', sa.Numeric(10, 2), nullable=False))
+    op.add_column('products', sa.Column('length', sa.Numeric(10, 2), nullable=False))
+    op.add_column('products', sa.Column('height', sa.Numeric(10, 2), nullable=False))
+    op.add_column('products', sa.Column('selling_cost', sa.Numeric(10, 2), nullable=False))
+    op.add_column('products', sa.Column('production_cost', sa.Numeric(10, 2), nullable=False))
+    op.drop_column('products', 'discounted_price')
+    op.drop_column('products', 'discount')
+    op.drop_column('products', 'price')
+    op.drop_column('products', 'product_type')
+    op.drop_table('model3d_media')
+    op.drop_table('three_d_models')

--- a/app/crud.py
+++ b/app/crud.py
@@ -38,6 +38,8 @@ def create_guest_order(db: Session, order: schemas.GuestOrderBase):
     
     return db_order
 
+"""Product and 3D model CRUD helpers."""
+
 # Product CRUD
 def create_product(db: Session, product: schemas.ProductBase):
     db_product = models.Product(**product.dict())
@@ -69,24 +71,32 @@ def delete_product(db: Session, product_id: int):
     return db_product
 
 # Create
-def create_product_media(db: Session, media: schemas.ProductMediaCreate):
-    db_media = models.ProductMedia(**media.dict())
+def create_model3d(db: Session, model: schemas.Model3DCreate):
+    db_model = models.Model3D(**model.dict())
+    db.add(db_model)
+    db.commit()
+    db.refresh(db_model)
+    return db_model
+
+
+def create_model3d_media(db: Session, media: schemas.Model3DMediaCreate):
+    db_media = models.Model3DMedia(**media.dict())
     db.add(db_media)
     db.commit()
     db.refresh(db_media)
     return db_media
 
-# Read - all media for a given product
-def get_media_for_product(db: Session, product_id: int):
-    return db.query(models.ProductMedia).filter(models.ProductMedia.product_id == product_id).all()
 
-# Read - get by id
-def get_product_media_by_id(db: Session, media_id: int):
-    return db.query(models.ProductMedia).filter(models.ProductMedia.id == media_id).first()
+def get_media_for_model3d(db: Session, model3d_id: int):
+    return db.query(models.Model3DMedia).filter(models.Model3DMedia.model3d_id == model3d_id).all()
 
-# Delete
-def delete_product_media(db: Session, media_id: int):
-    db_media = db.query(models.ProductMedia).filter(models.ProductMedia.id == media_id).first()
+
+def get_model3d_media_by_id(db: Session, media_id: int):
+    return db.query(models.Model3DMedia).filter(models.Model3DMedia.id == media_id).first()
+
+
+def delete_model3d_media(db: Session, media_id: int):
+    db_media = db.query(models.Model3DMedia).filter(models.Model3DMedia.id == media_id).first()
     if db_media is None:
         return None
     db.delete(db_media)

--- a/app/main.py
+++ b/app/main.py
@@ -120,38 +120,35 @@ def delete_product(product_id: int, db: Session = Depends(get_db_session), curre
         raise HTTPException(status_code=404, detail="Product not found")
     return db_product
 
-@app.post("/product_media/", response_model=schemas.ProductMedia)
-def create_product_media(
-    media: schemas.ProductMediaCreate,
+@app.post("/model3d_media/", response_model=schemas.Model3DMedia)
+def create_model3d_media(
+    media: schemas.Model3DMediaCreate,
     db: Session = Depends(get_db_session),
     current_user: models.User = Depends(admin_required),
 ):
-    # Optionally, check if product exists here.
-    return crud.create_product_media(db=db, media=media)
+    return crud.create_model3d_media(db=db, media=media)
 
-# Get all media for a product (public)
-@app.get("/product_media/product/{product_id}", response_model=List[schemas.ProductMedia])
-def get_media_for_product(
-    product_id: int,
+@app.get("/model3d_media/model/{model3d_id}", response_model=List[schemas.Model3DMedia])
+def get_media_for_model3d(
+    model3d_id: int,
     db: Session = Depends(get_db_session),
 ):
-    return crud.get_media_for_product(db=db, product_id=product_id)
+    return crud.get_media_for_model3d(db=db, model3d_id=model3d_id)
 
-# Delete a ProductMedia entry (admin only)
-@app.delete("/product_media/{media_id}", response_model=schemas.ProductMedia)
-def delete_product_media(
+@app.delete("/model3d_media/{media_id}", response_model=schemas.Model3DMedia)
+def delete_model3d_media(
     media_id: int,
     db: Session = Depends(get_db_session),
     current_user: models.User = Depends(admin_required),
 ):
-    db_media = crud.delete_product_media(db=db, media_id=media_id)
+    db_media = crud.delete_model3d_media(db=db, media_id=media_id)
     if db_media is None:
         raise HTTPException(status_code=404, detail="Media not found")
     return db_media
 
-@app.post("/product_media/upload/", response_model=schemas.ProductMedia)
-def upload_product_media(
-    product_id: int = Form(...),
+@app.post("/model3d_media/upload/", response_model=schemas.Model3DMedia)
+def upload_model3d_media(
+    model3d_id: int = Form(...),
     media_type: str = Form(...),  # "image" or "model"
     file: UploadFile = File(...),
     db: Session = Depends(get_db_session),
@@ -160,12 +157,12 @@ def upload_product_media(
     file_bytes = file.file.read()
     if not file_bytes:
         raise HTTPException(status_code=400, detail="Empty file")
-    db_media = models.ProductMedia(
-        product_id=product_id,
+    db_media = models.Model3DMedia(
+        model3d_id=model3d_id,
         media_type=media_type,
         filename=file.filename,
         content_type=file.content_type or "application/octet-stream",
-        data=file_bytes
+        data=file_bytes,
     )
     db.add(db_media)
     db.commit()
@@ -174,7 +171,7 @@ def upload_product_media(
 
 @app.get("/media/{media_id}")
 def get_media_file(media_id: int, db: Session = Depends(get_db_session)):
-    media = db.query(models.ProductMedia).filter(models.ProductMedia.id == media_id).first()
+    media = db.query(models.Model3DMedia).filter(models.Model3DMedia.id == media_id).first()
     if not media:
         raise HTTPException(status_code=404, detail="Media not found")
     return Response(

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean ,Numeric, ForeignKey, Table, DateTime, LargeBinary
+from sqlalchemy import Column, Integer, String, Boolean, Numeric, ForeignKey, Table, DateTime, LargeBinary
 from sqlalchemy.orm import relationship
 from .database import Base
 from datetime import datetime
@@ -27,19 +27,20 @@ class User(Base):
 
 
 class Product(Base):
+    """Generic product information shared across all product types."""
+
     __tablename__ = "products"
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
-    production_cost = Column(Numeric(10, 2), nullable=False)
-    selling_cost = Column(Numeric(10, 2), nullable=False)
-    height = Column(Numeric(10, 2), nullable=False)
-    length = Column(Numeric(10, 2), nullable=False)
-    depth = Column(Numeric(10, 2), nullable=False)
+    product_type = Column(String, nullable=False)
     quantity = Column(Integer, nullable=False)
+    price = Column(Numeric(10, 2), nullable=False)
+    discount = Column(Numeric(10, 2), nullable=True)
+    discounted_price = Column(Numeric(10, 2), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
-    media = relationship("ProductMedia", back_populates="product")
+    model3d = relationship("Model3D", back_populates="product", uselist=False)
     categories = relationship("Category", secondary=product_categories, back_populates="products")
 
 class Category(Base):
@@ -50,16 +51,31 @@ class Category(Base):
 
     products = relationship("Product", secondary=product_categories, back_populates="categories")
 
-class ProductMedia(Base):
-    __tablename__ = "product_media"
+class Model3D(Base):
+    """Specific information for 3D model products."""
+
+    __tablename__ = "three_d_models"
+
+    id = Column(Integer, primary_key=True, index=True)
+    product_id = Column(Integer, ForeignKey("products.id"), nullable=False, unique=True)
+    height = Column(Numeric(10, 2), nullable=False)
+    length = Column(Numeric(10, 2), nullable=False)
+    width = Column(Numeric(10, 2), nullable=False)
+
+    product = relationship("Product", back_populates="model3d")
+    media = relationship("Model3DMedia", back_populates="model3d")
+
+
+class Model3DMedia(Base):
+    __tablename__ = "model3d_media"
     id = Column(Integer, primary_key=True)
-    product_id = Column(Integer, ForeignKey("products.id"), nullable=False)
+    model3d_id = Column(Integer, ForeignKey("three_d_models.id"), nullable=False)
     media_type = Column(String, nullable=False)
     filename = Column(String, nullable=False)
-    content_type = Column(String, nullable=False)  
-    data = Column(LargeBinary, nullable=False)     
+    content_type = Column(String, nullable=False)
+    data = Column(LargeBinary, nullable=False)
 
-    product = relationship("Product", back_populates="media")
+    model3d = relationship("Model3D", back_populates="media")
 
 class Order(Base):
     __tablename__ = "orders"

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -16,37 +16,57 @@ class User(UserBase):
     class Config:
         orm_mode = True
 
-class ProductMediaBase(BaseModel):
-    product_id: int
+class Model3DMediaBase(BaseModel):
+    model3d_id: int
     media_type: str
     filename: str
     content_type: str
 
-class ProductMediaCreate(ProductMediaBase):
+class Model3DMediaCreate(Model3DMediaBase):
     pass
 
-class ProductMedia(ProductMediaBase):
+class Model3DMedia(Model3DMediaBase):
     id: int
+    class Config:
+        orm_mode = True
+
+
+class Model3DBase(BaseModel):
+    height: float
+    length: float
+    width: float
+
+
+class Model3DCreate(Model3DBase):
+    product_id: int
+
+
+class Model3D(Model3DBase):
+    id: int
+    product_id: int
+    media: List[Model3DMedia] = []
+
     class Config:
         orm_mode = True
 
 
 class ProductBase(BaseModel):
     name: str
-    production_cost: float
-    selling_cost: float
-    height: float
-    length: float
-    depth: float
+    product_type: str
     quantity: int
+    price: float
+    discount: Optional[float] = None
+    discounted_price: Optional[float] = None
+
 
 class ProductCreate(ProductBase):
     pass
 
+
 class Product(ProductBase):
     id: int
-    media: List[ProductMedia] = []
     created_at: datetime
+    model3d: Optional[Model3D] = None
 
     class Config:
         orm_mode = True

--- a/upload_data_to_db.py
+++ b/upload_data_to_db.py
@@ -8,13 +8,17 @@ from sqlalchemy.orm import Session
 DATA_FOLDER = os.path.join(os.path.dirname(__file__), "data")
 ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".glb"]
 
-def list_products(db: Session):
-    products = db.query(models.Product).all()
-    print("\nAvailable Products:")
-    for p in products:
-        print(f"{p.id}: {p.name}")
+def list_models(db: Session):
+    models3d = db.query(models.Model3D).all()
+    print("\nAvailable 3D Models:")
+    mapping = {}
+    for m in models3d:
+        prod = db.query(models.Product).filter(models.Product.id == m.product_id).first()
+        name = prod.name if prod else f"Product {m.product_id}"
+        print(f"{m.id}: {name}")
+        mapping[str(m.id)] = name
     print("")
-    return {str(p.id): p.name for p in products}
+    return mapping
 
 def guess_media_type(filename):
     ext = filename.lower().split('.')[-1]
@@ -27,12 +31,12 @@ def guess_media_type(filename):
     else:
         return None, None
 
-def upload_media(product_id, media_type, content_type, filepath, db):
+def upload_media(model3d_id, media_type, content_type, filepath, db):
     filename = os.path.basename(filepath)
     with open(filepath, "rb") as f:
         file_bytes = f.read()
-    db_media = models.ProductMedia(
-        product_id=product_id,
+    db_media = models.Model3DMedia(
+        model3d_id=model3d_id,
         media_type=media_type,
         filename=filename,
         content_type=content_type,
@@ -41,11 +45,11 @@ def upload_media(product_id, media_type, content_type, filepath, db):
     db.add(db_media)
     db.commit()
     db.refresh(db_media)
-    print(f"  Uploaded {filename} as {media_type} to product ID {product_id}.")
+    print(f"  Uploaded {filename} as {media_type} to model ID {model3d_id}.")
 
 if __name__ == "__main__":
     db = SessionLocal()
-    product_dict = list_products(db)
+    model_dict = list_models(db)
     db.close()
 
     # Scan for folders inside the data directory
@@ -69,23 +73,23 @@ if __name__ == "__main__":
         for filename in files:
             print(f"  {filename}")
 
-        product_dict = list_products(db)
+        model_dict = list_models(db)
         while True:
-            product_id = input(f"Enter the product ID to assign ALL files in '{folder}' to (or blank to skip): ").strip()
-            if not product_id:
+            model_id = input(f"Enter the 3D model ID to assign ALL files in '{folder}' to (or blank to skip): ").strip()
+            if not model_id:
                 print(f"Skipping folder '{folder}'.")
                 break
-            if product_id in product_dict:
+            if model_id in model_dict:
                 for filename in files:
                     filepath = os.path.join(folder_path, filename)
                     media_type, content_type = guess_media_type(filename)
                     if not media_type or not content_type:
                         print(f"  Skipping {filename}: unsupported file type.")
                         continue
-                    upload_media(int(product_id), media_type, content_type, filepath, db)
+                    upload_media(int(model_id), media_type, content_type, filepath, db)
                 break
             else:
-                print(f"Invalid product ID. Please enter a valid product ID.")
+                print(f"Invalid model ID. Please enter a valid model ID.")
 
     db.close()
     print("\nAll folders processed.")


### PR DESCRIPTION
## Summary
- Introduce generic `products` table with pricing and type fields
- Add `three_d_models` and `model3d_media` tables for 3D model specifics
- Update CRUD, API routes, and upload script for new model structure
- Provide Alembic migration for schema changes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61e653f8483259753801f76cfe3d8